### PR TITLE
Add error handling to some parts, change the way how the JSON decoder gets called.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 )
 
@@ -43,11 +42,13 @@ type Options struct {
 func ReadConfig() (Config, error) {
 	file, e := ioutil.ReadFile("./config/config.json")
 	if e != nil {
-		fmt.Printf("File error: %v\n", e)
 		return Config{}, e
 	}
 
 	var objectConfig Config
-	json.Unmarshal(file, &objectConfig)
+	if err := json.Unmarshal(file, &objectConfig); err != nil {
+		return Config{}, err
+	}
+
 	return objectConfig, nil
 }

--- a/main.go
+++ b/main.go
@@ -3,16 +3,13 @@ package main
 import (
 	"log"
 	"net/http"
-	"runtime"
+
+	"github.com/douglasmakey/ursho/config"
 	"github.com/douglasmakey/ursho/handlers"
 	"github.com/douglasmakey/ursho/storages"
-	"github.com/douglasmakey/ursho/config"
 )
 
 func main() {
-	// Sets the maximum number of CPUs
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Set use storage, select [Postgres, Filesystem, Redis ...]
 	storage := &storages.Postgres{}
 
@@ -22,8 +19,8 @@ func main() {
 		log.Fatal(err)
 	}
 	// Init storage
-	err = storage.Init(config)
-	if err != nil {
+
+	if err = storage.Init(config); err != nil {
 		log.Fatal(err)
 	}
 
@@ -36,7 +33,7 @@ func main() {
 	http.Handle("/info/", handlers.DecodeHandler(storage))
 
 	// Init server
-	err = http.ListenAndServe(config.Server.Host + ":" + config.Server.Port, nil)
+	err = http.ListenAndServe(config.Server.Host+":"+config.Server.Port, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/storages/postgres.go
+++ b/storages/postgres.go
@@ -3,6 +3,7 @@ package storages
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/douglasmakey/ursho/config"
 	_ "github.com/lib/pq"
 


### PR DESCRIPTION
Hay there! Chilean here :smile:

I made some modifications to the code:

* There were some places where there was no error checking, I added some of those.
* There's no need to keep the decoder in a variable if you won't use it later, better scope it into the if condition so the garbage collector can remove it later on.
* `runtime.GOMAXPROCS(runtime.NumCPU())` is no longer needed since a couple of Go versions ago. Now the runtime makes this decision automatically, pretty much with the same code you had before. By doing this here, it interferes with the ability of a Go program to allow the end user to pass an env var that may change this value later on.

Some other considerations for the future:

* `handlers/base.go` pretty much has 3 functions that do the same thing: printing something to the `ResponseWriter`. It'll be better if this is just one function. Take a look at `http.Error()` how it works.
* Try thinking about using `defer` to unlock mutexes. Some of the functions called in the `storage/filesystem` part may fail, and the unlock never gets called. A good example here [is this part](https://github.com/facebook-developer-circle-santiago/ursho/blob/289700159c423918bd296135979a665bb19f7096/storages/filesystem.go#L42-L48) where if there is an error, the mutex never gets unlocked.
* Consider returning pointers: by returning pointers you can make the first element of the duo returned always to be `nil`, which makes things easier to read and avoid extra allocations such as saying `return Config{}, err`.
* When working with `ioutils`, some of the files being returned may not be accessable, not be files, or be hidden or protected. [Counting them all without checking](https://github.com/facebook-developer-circle-santiago/ursho/blob/master/storages/filesystem.go#L36) if they're valid may not be okay.
* Instead of using `ioutil` to read and write, you might want to yield to the scheduler to do other operations. `ioutil` is somehow considered a stop-the-world operation (pretty much like an infinite for loop in the main.go), better use some buffers / streaming data by using the `os` package. It's more lines of code, but it leads to a more maintainable code, plus you can pipe the file being read directly to the JSON marshal / unmarshal flow, [and avoid extra conversions](https://github.com/facebook-developer-circle-santiago/ursho/blob/master/storages/filesystem.go#L55-L60).
* In the handlers, there's no verb handling, meaning all operations accept GET, POST, PUT, PATCH... requests. You might want to wrap then in a middleware, check if it's only available via one verb, and then return 404 for the others.
* There's no graceful shutdown, which means that the postgres connection are not being closed, or files being written may be kept captive from their file descriptors. Facebook itself [has a graceful-shutdown package here which it's easy to implement](https://github.com/facebookgo/grace).

I'm here for any questions!
Saludos, coterráneos!